### PR TITLE
feat: infer `config.base` from `package.json#name`, print `outDir` and branch in `onPublish` callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ export default defineConfig({
 });
 ```
 
+If no `base` value is provided, the plugin will attempt to infer the value using the value of `package.json#name`.
+
 ## Options
 
 Pass additional options to `gh-pages`:

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ This plugin uses [gh-pages](https://github.com/tschaub/gh-pages) to publish your
 
 **Steps**
 
-1. Infer the publish directory using `config.build.outDir` from the `configResolved` Vite hook
-2. Create a `<outDir>/.nojekyll` file to opt-out of Jekyll mode
-3. Use `gh-pages` to publish the `outDir` to GitHub Pages
+1. Infer the publish directory from the `build.outDir` value
+2. Infer the GitHub Pages destination URL from the `package.json#name` if `base` is not set
+3. Create a `<outDir>/.nojekyll` file to opt-out of Jekyll mode
+4. Use `gh-pages` to publish the `outDir` to GitHub Pages
 
 ## Installation
 
@@ -25,7 +26,7 @@ pnpm i -D vite-plugin-gh-pages
 
 ## Usage
 
-You must specify a [public base path](https://vitejs.dev/guide/build.html#public-base-path) for your app to work on GitHub Pages.
+Vite requires a [public base path](https://vitejs.dev/guide/build.html#public-base-path) for your app to work on GitHub Pages.
 
 For example, if your repository name is "repo-name," `base` should be `/repo-name/`.
 
@@ -44,7 +45,7 @@ If no `base` value is provided, the plugin will attempt to infer the value using
 
 ## Options
 
-Pass additional options to `gh-pages`:
+Pass additional options to `gh-pages`.
 
 ```js
 ghPages({
@@ -165,9 +166,7 @@ interface GhPagesOptions {
 }
 ```
 
-## Optional callbacks
-
-### `onPublish`
+## `onPublish` / `onError` callbacks
 
 The `onPublish` callback will be invoked if `gh-pages` has successfully published the folder.
 
@@ -175,9 +174,12 @@ The `onPublish` callback will be invoked if `gh-pages` has successfully publishe
 
 ```js
 ghPages({
-  onPublish: () => {
+  /** @type {options: GhPagesOptions & { outDir: string } => void} */
+  onPublish: (options) => {
     // ...
   },
+
+  /** @type {(error: any) => void} **/
   onError: (error) => {
     // ...
   },

--- a/example/package.json
+++ b/example/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "vite-plugin-gh-pages",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/example/vite.config.js
+++ b/example/vite.config.js
@@ -2,11 +2,5 @@ import { defineConfig } from "vite";
 import { ghPages } from "vite-plugin-gh-pages";
 
 export default defineConfig({
-  plugins: [
-    ghPages({
-      onPublish: () => {
-        console.log("🎉");
-      },
-    }),
-  ],
+  plugins: [ghPages()],
 });

--- a/example/vite.config.js
+++ b/example/vite.config.js
@@ -2,7 +2,6 @@ import { defineConfig } from "vite";
 import { ghPages } from "vite-plugin-gh-pages";
 
 export default defineConfig({
-  base: "/vite-plugin-gh-pages/",
   plugins: [
     ghPages({
       onPublish: () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,18 @@ const resolvePkgJson = (): null | { name?: string } => {
 export const ghPages = (options?: GhPagesOptions): Plugin => {
   let outDir = "";
 
+  const onError: GhPagesOptions["onError"] =
+    options?.onError ??
+    ((error) => {
+      console.log(error);
+    });
+
+  const onPublish: GhPagesOptions["onPublish"] =
+    options?.onPublish ??
+    (() => {
+      console.log("🎉 Published.");
+    });
+
   return {
     name: "vite:gh-pages",
     apply: "build",
@@ -47,13 +59,8 @@ export const ghPages = (options?: GhPagesOptions): Plugin => {
           ...options,
         },
         (error) => {
-          if (error) {
-            options?.onError?.(error);
-            console.log(error);
-            return;
-          }
-          options?.onPublish?.();
-          console.log("Published.");
+          if (error) return onError(error);
+          onPublish();
         }
       );
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export const ghPages = (options?: GhPagesOptions): Plugin => {
   return {
     name: "vite:gh-pages",
     apply: "build",
+    enforce: "post",
     configResolved(resolvedConfig) {
       outDir = resolvedConfig.build.outDir;
     },


### PR DESCRIPTION
- infer Vite `config.base` from the `package.json#name`
- print the `outDir` and branch name in the default `onPublish` callback
- set `enforce: "post"` to invoke plugin after vite build plugins
- `onPublish` / `onError` callbacks should override the default messages
