### PR TITLE
fix: handle invalid `package.json` or JSON parse errors

### DIFF
--- a/src/get-package-name.ts
+++ b/src/get-package-name.ts
@@ -1,10 +1,19 @@
 import fs from "node:fs";
 import path from "node:path";
 
-export const getPackageName = (): undefined | string => {
-  const pkg_path = path.join(process.cwd(), "package.json");
-  if (!fs.existsSync(pkg_path)) return;
+export const getPackageName = (): string | undefined => {
+  try {
+    const pkg_path = path.join(process.cwd(), "package.json");
+    const content = fs.readFileSync(pkg_path, "utf-8");
+    const pkg = JSON.parse(content);
 
-  const pkg = JSON.parse(fs.readFileSync(pkg_path, "utf-8"));
-  return pkg?.name ?? undefined;
+    if (!pkg?.name || typeof pkg.name !== "string") {
+      return undefined;
+    }
+
+    return pkg.name;
+  } catch (error) {
+    // Handle file reading and JSON parsing errors.
+    return undefined;
+  }
 };

--- a/tests/get-package-name.test.ts
+++ b/tests/get-package-name.test.ts
@@ -37,4 +37,11 @@ describe("getPackageName", () => {
 
     expect(getPackageName()).toBe("test-package");
   });
+
+  test("returns undefined when package.json contains invalid JSON", () => {
+    vi.spyOn(fs, "readFileSync").mockReturnValue("{ invalid json }");
+    vi.spyOn(path, "join").mockReturnValue("/fake/path/package.json");
+
+    expect(getPackageName()).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Fail open if the `package.json` is invalid or there are otherwise JSON parsing errors.